### PR TITLE
MBA-7 Blogセクション「その他記事」の遷移先を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       <a href="https://motorogu-essays-in-idleness.com/%e3%81%93%e3%82%93%e3%81%ab%e3%81%a1%e3%81%af%ef%bc%81moto%e3%81%a7%e3%81%99%ef%bc%81/"></a>
       <p>これ分かってないと無理！ダイエットしたい人へ<br>初歩的な栄養学の基本を解説</p>
     </div>
-    <a href="https://motorogu-essays-in-idleness.com/" class="blog-button">記事一覧</a>
+    <a href="https://motorogu-essays-in-idleness.com/author/love-baseball-boy8989gmail-com/" class="blog-button">記事一覧</a>
   </section>
 
   <section class="phrase-sec" id="phrase-area">


### PR DESCRIPTION
「その他記事」の遷移先が https://motorogu-essays-in-idleness.com/ （トップページ）に設定されているため、https://motorogu-essays-in-idleness.com/author/love-baseball-boy8989gmail-com/ （ブログ記事一覧）に変更する。

<img width="517" height="503" alt="スクリーンショット 2025-09-01 19 03 08" src="https://github.com/user-attachments/assets/f8cd80f2-028a-47ab-a45e-84d1b6db80fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the BLOG section’s “記事一覧” link to direct users to the specific author page instead of the site homepage, ensuring they land on the intended article list.
  * No changes to link text or visual styling; only the destination URL was adjusted.
  * Improves navigation by taking users straight to the author’s posts, reducing extra clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->