### PR TITLE
Add Vercel configuration for design preview environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 
 # Playwright MCP
 .playwright-mcp/
+
+# Vercel
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "version": 2,
   "buildCommand": null,
   "outputDirectory": ".",
+  "ignoreCommand": "[[ \"$VERCEL_GIT_COMMIT_REF\" != design-renewal/* ]]",
   "cleanUrls": true,
   "trailingSlash": false,
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "buildCommand": null,
+  "outputDirectory": ".",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    }
+  ],
+  "git": {
+    "deploymentEnabled": {
+      "main": false,
+      "main_stg": false,
+      "main_dev": false
+    }
+  }
+}


### PR DESCRIPTION
- Add vercel.json with noindex headers and deployment settings
- Update .gitignore to exclude .vercel directory
- Configure to disable deployment on main, main_stg, main_dev branches
- Enable deployment only for design-renewal/* branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added hosting configuration enabling clean URLs (no trailing slashes) and a global X-Robots-Tag header set to noindex,nofollow.
  * Disabled automatic deployments for main and related branches and added rules to skip builds for specific refs.
  * Updated ignore settings to exclude the hosting deployment directory from source control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->