### PR TITLE
fix: 本番環境のnoindexをコメントアウトに戻す

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>奥沢・自由が丘のパーソナルジム｜ストレッチ＆マッサージ対応｜STRETCH&STRENGTH</title>
   <meta name="description" content="奥沢・自由が丘の完全個室パーソナルジム「STRETCH&STRENGTH」。ストレッチ×トレーニングで姿勢改善・不調予防を実現。奥沢/緑が丘/自由が丘駅徒歩圏、LINEで簡単予約。">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex" />
+  <!--<meta name="robots" content="noindex" />-->
   <link rel="icon" type="image/png" href="images/favicon.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/service.html
+++ b/service.html
@@ -5,7 +5,7 @@
   <title>奥沢・自由が丘のパーソナルジム｜プログラム・料金・予約｜STRETCH&STRENGTH</title>
   <meta name="description" content="プログラム・料金・予約のご案内｜STRETCH&STRENGTH（奥沢・自由が丘）。科学的根拠に基づくトレーニングとペアストレッチ。料金プラン・初回の流れ・予約方法を掲載。">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex" />
+  <!--<meta name="robots" content="noindex" />-->
   <link rel="icon" type="image/png" href="images/favicon.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- pattern-c デザインリニューアル適用コミット (`ca38e18`) 以降、本番ルール上コメントアウトされているべき `<meta name="robots" content="noindex" />` が有効化された状態で main にマージされていた
- 本番サイト (motorogu-essays-in-idleness.com) が noindex 状態となり、Google 検索ランキングに影響
- `index.html` / `service.html` の noindex を本番運用ルール通りコメントアウト状態へ戻す

## 原因
- 直接原因コミット: `ca38e18 デザインリニューアル（pattern-c適用）`
- `auto-merge-to-stg.yml` は main_stg 側でのみ sed を実行するためワークフロー由来ではない
- pattern-c ブランチ作業中に noindex を有効化したまま main にマージしたものと推測

## Test plan
- [ ] `auto-merge-to-stg.yml` で main_stg に noindex 有効化コミットが入る
- [ ] main マージ後、`deploy.yml` で本番に FTPS デプロイされる
- [ ] 本番の `<head>` 内 robots meta がコメントアウト状態である
- [ ] Google Search Console から再クロール / インデックス登録をリクエスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine indexing configuration for website pages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koukou8/stretch-strength-homepage/pull/61)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->