### PR TITLE
fix: robots.txt と sitemap.xml を追加（本番のPHPエラー解消）

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
-Allow: /
+Disallow: /wp-admin/
+Allow: /wp-admin/admin-ajax.php
 
 Sitemap: https://motorogu-essays-in-idleness.com/sitemap.xml
+Sitemap: https://motorogu-essays-in-idleness.com/wp-sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://motorogu-essays-in-idleness.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://motorogu-essays-in-idleness.com/</loc>
+    <lastmod>2026-05-11</lastmod>
+  </url>
+  <url>
+    <loc>https://motorogu-essays-in-idleness.com/service.html</loc>
+    <lastmod>2026-05-11</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- 本番の `robots.txt` が WordPress プラグイン Invisible reCAPTCHA の PHP 8.1+ 非互換問題で PHP Warning を出力し、Search Console が「構文が認識できませんでした」エラーを返している状態を解消
- 静的 `robots.txt` をリポジトリ直下に配置することで WordPress の動的生成を上書きし、クローラーに正しい指示を返す
- 合わせて `sitemap.xml`（index.html / service.html の2ページ）を追加し、`Sitemap:` 宣言先をジムサイト用に統一

## 背景
Search Console の robots.txt レポートで「構文が認識できませんでした (line 2)」エラーが検出されていた。本番の `robots.txt` には WordPress プラグイン Invisible reCAPTCHA のPHPエラー（`__wakeup() must have public visibility`）が冒頭に出力されており、Google が指示行を正しく解釈できない状態だった。

ConoHa Wing の docroot では Apache が物理ファイルを最優先で返すため、リポジトリ直下に静的ファイルを配置すれば WordPress の動的生成より優先される。

## Test plan
- [ ] STG（main_stg 自動マージ後）に GitHub Pages 経由でデプロイされることを確認
- [ ] 本番マージ後、`https://motorogu-essays-in-idleness.com/robots.txt` を開き、PHP Warning が消えていることを確認
- [ ] `https://motorogu-essays-in-idleness.com/sitemap.xml` に index.html と service.html の2URLが含まれることを確認
- [ ] Search Console の robots.txt 設定画面で「再クロールをリクエスト」を実行
- [ ] Search Console で `sitemap.xml` を手動送信

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented crawler directives in the site configuration file, permitting all user agents to access and index the root path while specifying the XML sitemap location for reference.
  * Created an XML sitemap documenting key site pages (root and service section) with their respective last modification dates to provide comprehensive site structure information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koukou8/stretch-strength-homepage/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->